### PR TITLE
Handle pagerank zerodivisionerror gracefully

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -398,7 +398,10 @@ class RepoMap:
         try:
             ranked = nx.pagerank(G, weight="weight", **pers_args)
         except ZeroDivisionError:
-            return []
+            try:
+                ranked = nx.pagerank(G, weight="weight")
+            except ZeroDivisionError:
+                return []
 
         # distribute the rank from each source node, across all of its out edges
         ranked_definitions = defaultdict(float)


### PR DESCRIPTION
Retry `nx.pagerank` without personalized arguments on `ZeroDivisionError` to provide a more robust fallback.

The original implementation would immediately return an empty list if `nx.pagerank` failed with a `ZeroDivisionError` when personalized arguments were provided. This change introduces a retry mechanism, attempting to calculate PageRank without personalization if the personalized attempt fails, thus avoiding an unnecessary empty result.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f88c1bf-9ce2-4185-b523-45067a4fb045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f88c1bf-9ce2-4185-b523-45067a4fb045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

